### PR TITLE
A Couple Small Fixes

### DIFF
--- a/Lumiverse/source/LumiverseCore/DMX/KiNetInterface.cpp
+++ b/Lumiverse/source/LumiverseCore/DMX/KiNetInterface.cpp
@@ -57,7 +57,7 @@ void KiNetInterface::init() {
     free(m_buffer);
 
   m_buffer = (unsigned char*)malloc(getBufferSize() * sizeof(unsigned char));
-  memset(m_buffer, (int)getBufferSize(), 0);
+  memset(m_buffer, 0, (int)getBufferSize());
   for (int c = 0; c < getNumChannels(); c++)
   {
     memcpy(m_buffer + c * getPacketSize(), getHeaderBytes(), getHeaderSize());

--- a/Lumiverse/source/LumiverseCore/lib/clp/ClpPdco.cpp
+++ b/Lumiverse/source/LumiverseCore/lib/clp/ClpPdco.cpp
@@ -316,9 +316,7 @@ ClpPdco::pdco( ClpPdcoBase * stuff, Options &options, Info &info, Outfo &outfo)
      //bool useChol = (LSmethod == 1);
      //bool useQR   = (LSmethod == 2);
      bool direct  = (LSmethod <= 2 && ifexplicit);
-     char solver[6];
-     strcpy(solver, "  LSQR");
-
+     char solver[7] = "  LSQR";
 
      //---------------------------------------------------------------------
      // Categorize bounds and allow for fixed variables by modifying b.

--- a/Lumiverse/source/LumiverseCore/lib/clp/ClpPdco.cpp
+++ b/Lumiverse/source/LumiverseCore/lib/clp/ClpPdco.cpp
@@ -316,7 +316,8 @@ ClpPdco::pdco( ClpPdcoBase * stuff, Options &options, Info &info, Outfo &outfo)
      //bool useChol = (LSmethod == 1);
      //bool useQR   = (LSmethod == 2);
      bool direct  = (LSmethod <= 2 && ifexplicit);
-     char solver[7] = "  LSQR";
+     char solver[7];
+     strncpy(solver, "  LSQR", 7);
 
      //---------------------------------------------------------------------
      // Categorize bounds and allow for fixed variables by modifying b.


### PR DESCRIPTION
The arguments to `memset` in `KiNetInterface.cpp` are transposed, so the function doesn't actually clear the buffer.

The `strcpy` in `ClpPdco.cpp` is unsafe because the string literal is 7 characters long when including the NULL byte.